### PR TITLE
Change TimestampT in EventLog back to system_clock

### DIFF
--- a/include/react/logging/EventLog.h
+++ b/include/react/logging/EventLog.h
@@ -29,7 +29,7 @@
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 class EventLog
 {
-    using TimestampT = std::chrono::time_point<std::chrono::high_resolution_clock>;
+    using TimestampT = std::chrono::time_point<std::chrono::system_clock>;
 
     class Entry
     {


### PR DESCRIPTION
This fixes a compilation error with clang/libc++ on Mac OS 10.9.

I'm guessing you swapped TimestampT over to high_resolution_clock for benchmarking and forgot to swap it back to system_clock.
